### PR TITLE
 Fix for starting the service before writing a new config.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "miah@cx.com"
 license          "Apache 2.0"
 description      "Installs/configures redis"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.4"
+version          "1.0.5"
 
 recipe "redis::_group", "Creates a group for Redis."
 recipe "redis::_server_config", "Creates configuration directories and installs templatized redis.conf."

--- a/recipes/server_package.rb
+++ b/recipes/server_package.rb
@@ -21,5 +21,5 @@
 include_recipe "redis::_group"
 include_recipe "redis::_user"
 include_recipe "redis::_server_install_from_package"
-include_recipe "redis::_server_service"
 include_recipe "redis::_server_config"
+include_recipe "redis::_server_service"


### PR DESCRIPTION
If you ever get into a situation where the configuration is wrong and redis can't start, the config won't ever be written again.

This fixes that situation by writing the new configuration before trying to start the server.
